### PR TITLE
Prepping Gorllia fork. Fixes #1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Go lang uses tabs by default
+[*.go]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Treat all files in this repo as binary, with no git magic updating
+# line endings. Windows users contributing to Go will need to use a
+# modern version of git and editors capable of LF line endings.
+#
+# We'll prevent accidental CRLF line endings from entering the repo
+# via the git-review gofmt checks.
+#
+# See golang.org/issue/9281
+
+* -text

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: tebruno99
+patreon: elasticperch

--- a/.github/ISSUE_TEMPLATE/🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/🐛-bug-report.md
@@ -1,0 +1,34 @@
+---
+name: "\U0001F41B Bug Report"
+about: Create a report to help us improve
+title: "[bug] "
+labels: bug
+assignees: tebruno99
+
+---
+
+**Describe the bug**
+> A clear and concise description of what the bug is.
+
+…
+
+**Versions**
+> Go version: `go version`
+> package version: run `git rev-parse HEAD` inside the repo
+
+…
+
+
+**Steps to Reproduce**
+> How can the bug be triggered?
+
+…
+
+
+**Expected behavior**
+> What output or behaviour were you expecting instead?
+
+…
+
+**Code Snippets**
+> A minimum viable code snippet can be useful! (use backticks to format it).

--- a/.github/ISSUE_TEMPLATE/💡-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/💡-feature-request.md
@@ -1,0 +1,23 @@
+---
+name: "\U0001F4A1 Feature Request"
+about: Suggest an idea for this project
+title: "[feature] "
+labels: feature request
+assignees: tebruno99
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+> A clear and concise description of what the problem is - e.g. "I'm always frustrated when [...]"
+
+…
+
+**Describe the solution you'd like**
+>What would the feature look like? How would it work? How would it change the API?
+
+…
+
+**Describe alternatives you've considered**
+> Are there alternatives you've tried, and/or workarounds in-place?
+
+…

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,185 @@
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mux.iml" filepath="$PROJECT_DIR$/.idea/mux.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/mux.iml
+++ b/.idea/mux.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,10 @@
+# This is the official list of elasticperch/mux authors for copyright purposes.
+#
+# Please keep the list sorted.
+
+Thomas Bruno (https://github.com/tebruno99), <past.plan4497@elasticperch.com>
+
+
 # This is the official list of gorilla/mux authors for copyright purposes.
 #
 # Please keep the list sorted.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,14 @@
-Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+=== ElasticPerch/mux ===
+Copyright (c) 2022 Thomas Bruno.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=== Gorilla Project ===
+Copyright (c) 2012-2022 The Gorilla Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# gorilla/mux
+# ElasticPerch/mux
 
-[![GoDoc](https://godoc.org/github.com/gorilla/mux?status.svg)](https://godoc.org/github.com/gorilla/mux)
-[![CircleCI](https://circleci.com/gh/gorilla/mux.svg?style=svg)](https://circleci.com/gh/gorilla/mux)
-[![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
-
-![Gorilla Logo](https://cloud-cdn.questionable.services/gorilla-icon-64.png)
+[![GoDoc](https://godoc.org/github.com/elasticperch/mux?status.svg)](https://godoc.org/github.com/elasticperch/mux)
+[![Sourcegraph](https://sourcegraph.com/github.com/elasticperch/mux/-/badge.svg)](https://sourcegraph.com/github.com/elasticperch/mux?badge)
 
 ---
 
-**The Gorilla project has been archived, and is no longer under active maintainenance. You can read more here: https://github.com/gorilla#gorilla-toolkit**
+The Gorilla project was archived on Dec 9, 2022. elasticperch/mux was forked from the master branch and existing PRs & issues linked to those PRs were copied to this project.
+Thank you to the Gorilla project maintainers for years of support, vision and direction for the community.
+
+The intention of the maintainers is to build on the original legacy while forming Our own vision and future for this project.
+ElasticPerch/mux is currently used in several Non-Profit & Commercial applications. Contributions are welcome.
 
 ---
 
-Package `gorilla/mux` implements a request router and dispatcher for matching incoming requests to
+Package `elasticperch/mux` implements a request router and dispatcher for matching incoming requests to
 their respective handler.
 
 The name mux stands for "HTTP request multiplexer". Like the standard `http.ServeMux`, `mux.Router` matches incoming requests against a list of registered routes and calls a handler for the route that matches the URL or other conditions. The main features are:
@@ -45,7 +46,7 @@ The name mux stands for "HTTP request multiplexer". Like the standard `http.Serv
 With a [correctly configured](https://golang.org/doc/install#testing) Go toolchain:
 
 ```sh
-go get -u github.com/gorilla/mux
+go get -u github.com/elasticperch/mux
 ```
 
 ## Examples
@@ -234,7 +235,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 // spaHandler implements the http.Handler interface, so we can use it
@@ -392,7 +393,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -455,7 +456,7 @@ import (
     "os/signal"
     "time"
 
-    "github.com/gorilla/mux"
+    "github.com/elasticperch/mux"
 )
 
 func main() {
@@ -472,7 +473,7 @@ func main() {
         WriteTimeout: time.Second * 15,
         ReadTimeout:  time.Second * 15,
         IdleTimeout:  time.Second * 60,
-        Handler: r, // Pass our instance of gorilla/mux in.
+        Handler: r, // Pass our instance of elasticperch/mux in.
     }
 
     // Run our server in a goroutine so that it doesn't block.
@@ -506,7 +507,7 @@ func main() {
 
 ### Middleware
 
-Mux supports the addition of middlewares to a [Router](https://godoc.org/github.com/gorilla/mux#Router), which are executed in the order they are added if a match is found, including its subrouters.
+Mux supports the addition of middlewares to a [Router](https://godoc.org/github.com/elasticperch/mux#Router), which are executed in the order they are added if a match is found, including its subrouters.
 Middlewares are (typically) small pieces of code which take one request, do something with it, and pass it down to another middleware or the final handler. Some common use cases for middleware are request logging, header manipulation, or `ResponseWriter` hijacking.
 
 Mux middlewares are defined using the de facto standard type:
@@ -586,7 +587,7 @@ Note: The handler chain will be stopped if your middleware doesn't call `next.Se
 
 ### Handling CORS Requests
 
-[CORSMethodMiddleware](https://godoc.org/github.com/gorilla/mux#CORSMethodMiddleware) intends to make it easier to strictly set the `Access-Control-Allow-Methods` response header.
+[CORSMethodMiddleware](https://godoc.org/github.com/elasticperch/mux#CORSMethodMiddleware) intends to make it easier to strictly set the `Access-Control-Allow-Methods` response header.
 
 * You will still need to use your own CORS handler to set the other CORS headers such as `Access-Control-Allow-Origin`
 * The middleware will set the `Access-Control-Allow-Methods` header to all the method matchers (e.g. `r.Methods(http.MethodGet, http.MethodPut, http.MethodOptions)` -> `Access-Control-Allow-Methods: GET,PUT,OPTIONS`) on a route
@@ -600,7 +601,7 @@ package main
 
 import (
 	"net/http"
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 func main() {
@@ -787,7 +788,7 @@ package main
 import (
     "net/http"
     "log"
-    "github.com/gorilla/mux"
+    "github.com/elasticperch/mux"
 )
 
 func YourHandler(w http.ResponseWriter, r *http.Request) {
@@ -806,4 +807,11 @@ func main() {
 
 ## License
 
-BSD licensed. See the LICENSE file for details.
+BSD-3 (Gorilla Project) and MIT (ElasticPerch) licensed. See the LICENSE file for details.
+
+### Special Thanks & History
+
+[Gorilla mux](http://github.com/gorilla/mux)  
+Gary Burd <gary@beagledreams.com>  
+Google LLC (https://opensource.google.com/)  
+Joachim Bauch <mail@joachim-bauch.de>

--- a/example_authentication_middleware_test.go
+++ b/example_authentication_middleware_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 // Define our struct

--- a/example_cors_method_middleware_test.go
+++ b/example_cors_method_middleware_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 func ExampleCORSMethodMiddleware() {

--- a/example_route_test.go
+++ b/example_route_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/elasticperch/mux"
 )
 
 // This example demonstrates setting a regular expression matcher for

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gorilla/mux
+module github.com/elasticperch/mux
 
 go 1.12

--- a/route.go
+++ b/route.go
@@ -432,7 +432,7 @@ func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
 // It accepts a sequence of schemes to be matched, e.g.: "http", "https".
 // If the request's URL has a scheme set, it will be matched against.
 // Generally, the URL scheme will only be set if a previous handler set it,
-// such as the ProxyHeaders handler from gorilla/handlers.
+// such as the ProxyHeaders handler from elasticperch/handlers.
 // If unset, the scheme will be determined based on the request's TLS
 // termination state.
 // The first argument to Schemes will be used when constructing a route URL.


### PR DESCRIPTION
Renaming of project, licenses, etc for new fork. Adding gitattribute and editorconfig for go. Add .gitignore. Fixes #1

Signed-off-by: Thomas Bruno <24335+tebruno99@users.noreply.github.com>