### PR TITLE
MIGRATED: Fix accidental double-escaping when Router.UseEncodedPath() is enabled

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1574,6 +1574,24 @@ func TestUseEncodedPath(t *testing.T) {
 	}
 }
 
+func TestUseEncodedPathEscaping(t *testing.T) {
+	r := NewRouter()
+	r.UseEncodedPath()
+
+	req, _ := http.NewRequest("GET", "http://localhost/foo/../bar%25", nil)
+	res := NewRecorder()
+	r.ServeHTTP(res, req)
+
+	if len(res.HeaderMap["Location"]) != 1 {
+		t.Fatalf("Expected redirect from path clean")
+	}
+
+	expected := "http://localhost/bar%25"
+	if res.HeaderMap["Location"][0] != expected {
+		t.Errorf("Expected redirect location to %s, found %s", expected, res.HeaderMap["Location"][0])
+	}
+}
+
 func TestWalkSingleDepth(t *testing.T) {
 	r0 := NewRouter()
 	r1 := NewRouter()


### PR DESCRIPTION
**MIGRATED**
Original PR: @nvx gorilla/mux#641

Fixes gorilla/mux#354
Fixes #10 

---

Bug originally mentioned in https://github.com/gorilla/mux/issues/354#issuecomment-899377755

Summary of Changes

When Router.UseEncodedPath() is enabled (and SkipClean is not enabled), a request to http://localhost/foo/../bar%25 causes a redirect to http://localhost/bar%2525 as there is a bug where this code path results in double-encoding (the % from the %25 is itself encoded as %25, resulting in %2525).

The expected output for this should have been a redirect to http://localhost/bar%25. A unit test for this behaviour has been added which originally failed with the following output:

Expected redirect location to http://localhost/bar%25, found http://localhost/bar%2525
The remaining changes allows the new unit test to pass and does not break any existing unit tests.