### PR TITLE
MIGRATED: Fix minor mistake in HeadersRegexp doc #14

### DIFF
--- a/route.go
+++ b/route.go
@@ -255,7 +255,7 @@ func (m headerRegexMatcher) Match(r *http.Request, match *RouteMatch) bool {
 // HeadersRegexp accepts a sequence of key/value pairs, where the value has regex
 // support. For example:
 //
-//     r := mux.NewRouter()
+//     r := mux.NewRouter().NewRoute()
 //     r.HeadersRegexp("Content-Type", "application/(text|json)",
 //               "X-Requested-With", "XMLHttpRequest")
 //


### PR DESCRIPTION
**MIGRATED** - See discussion upstream
Original PR: @Algebra8 gorilla/mux#667

Fixes gorilla/mux#666
Fixes #14 

Summary of Changes

Fixed mistake in [HeadersRegexp](https://github.com/gorilla/mux/blob/master/route.go#L258) docs.
PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!

Since this is a doc change I don't think it needs tests.